### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/421/197/943/421197943.geojson
+++ b/data/421/197/943/421197943.geojson
@@ -563,6 +563,9 @@
     ],
     "wof:country":"GW",
     "wof:created":1459009930,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"eb150b9abe2db4fa819176ec62fc5fa9",
     "wof:hierarchy":[
         {
@@ -574,7 +577,7 @@
         }
     ],
     "wof:id":421197943,
-    "wof:lastmodified":1566644170,
+    "wof:lastmodified":1582312240,
     "wof:name":"Bissau",
     "wof:parent_id":1108758205,
     "wof:placetype":"locality",

--- a/data/856/327/57/85632757.geojson
+++ b/data/856/327/57/85632757.geojson
@@ -1024,6 +1024,11 @@
     },
     "wof:country":"GW",
     "wof:country_alpha3":"GNB",
+    "wof:geom_alt":[
+        "naturalearth",
+        "naturalearth-display-terrestrial-zoom6",
+        "meso"
+    ],
     "wof:geomhash":"d06c981e08b9316ccb14790b3a4c0f3c",
     "wof:hierarchy":[
         {
@@ -1038,7 +1043,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1566643917,
+    "wof:lastmodified":1582312235,
     "wof:name":"Guinea Bissau",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/715/35/85671535.geojson
+++ b/data/856/715/35/85671535.geojson
@@ -271,6 +271,9 @@
         "wk:page":"Biombo Region"
     },
     "wof:country":"GW",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e05f6ba0c18fcfe998edd78b4f2defd2",
     "wof:hierarchy":[
         {
@@ -286,7 +289,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1566643914,
+    "wof:lastmodified":1582312234,
     "wof:name":"Biombo",
     "wof:parent_id":85632757,
     "wof:placetype":"region",

--- a/data/856/715/39/85671539.geojson
+++ b/data/856/715/39/85671539.geojson
@@ -536,6 +536,9 @@
         421197943
     ],
     "wof:country":"GW",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bb0502d34b5ab71bf0961241852eadf8",
     "wof:hierarchy":[
         {
@@ -551,7 +554,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1566643915,
+    "wof:lastmodified":1582312235,
     "wof:name":"Bissau",
     "wof:parent_id":85632757,
     "wof:placetype":"region",

--- a/data/856/715/43/85671543.geojson
+++ b/data/856/715/43/85671543.geojson
@@ -287,6 +287,9 @@
         "wk:page":"Bolama Region"
     },
     "wof:country":"GW",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"441957a235274ba4b62f996a0ad3ce0f",
     "wof:hierarchy":[
         {
@@ -302,7 +305,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1566643915,
+    "wof:lastmodified":1582312235,
     "wof:name":"Bolama",
     "wof:parent_id":85632757,
     "wof:placetype":"region",

--- a/data/856/715/47/85671547.geojson
+++ b/data/856/715/47/85671547.geojson
@@ -258,6 +258,9 @@
         "wk:page":"Cacheu Region"
     },
     "wof:country":"GW",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8dc42dcc60dbfaa52dc450a8409a4f41",
     "wof:hierarchy":[
         {
@@ -273,7 +276,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1566643916,
+    "wof:lastmodified":1582312235,
     "wof:name":"Cacheu",
     "wof:parent_id":85632757,
     "wof:placetype":"region",

--- a/data/856/715/51/85671551.geojson
+++ b/data/856/715/51/85671551.geojson
@@ -287,6 +287,9 @@
         "wk:page":"Oio Region"
     },
     "wof:country":"GW",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"dc2ccc3116027b404a4168c1e50c1ada",
     "wof:hierarchy":[
         {
@@ -302,7 +305,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1566643915,
+    "wof:lastmodified":1582312234,
     "wof:name":"Oio",
     "wof:parent_id":85632757,
     "wof:placetype":"region",

--- a/data/856/715/55/85671555.geojson
+++ b/data/856/715/55/85671555.geojson
@@ -277,6 +277,9 @@
         "wk:page":"Quinara Region"
     },
     "wof:country":"GW",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ed359ca4b15553835bf8214fd97d2cdf",
     "wof:hierarchy":[
         {
@@ -292,7 +295,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1566643916,
+    "wof:lastmodified":1582312235,
     "wof:name":"Quinara",
     "wof:parent_id":85632757,
     "wof:placetype":"region",

--- a/data/856/715/57/85671557.geojson
+++ b/data/856/715/57/85671557.geojson
@@ -271,6 +271,9 @@
         "wk:page":"Bafat\u00e1 Region"
     },
     "wof:country":"GW",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ba203f78146e74bf3390a9796ef09318",
     "wof:hierarchy":[
         {
@@ -286,7 +289,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1566643914,
+    "wof:lastmodified":1582312234,
     "wof:name":"Bafat\u00e1",
     "wof:parent_id":85632757,
     "wof:placetype":"region",

--- a/data/856/715/59/85671559.geojson
+++ b/data/856/715/59/85671559.geojson
@@ -277,6 +277,9 @@
         "wk:page":"Gab\u00fa Region"
     },
     "wof:country":"GW",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"24d58d6a17cbf3a51df23ced27a12bb3",
     "wof:hierarchy":[
         {
@@ -292,7 +295,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1566643914,
+    "wof:lastmodified":1582312234,
     "wof:name":"Gab\u00fa",
     "wof:parent_id":85632757,
     "wof:placetype":"region",

--- a/data/856/715/61/85671561.geojson
+++ b/data/856/715/61/85671561.geojson
@@ -274,6 +274,9 @@
         "wk:page":"Tombali Region"
     },
     "wof:country":"GW",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1a5642627d5248ecdfd2ad2d7ddca97a",
     "wof:hierarchy":[
         {
@@ -289,7 +292,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1566643913,
+    "wof:lastmodified":1582312234,
     "wof:name":"Tombali",
     "wof:parent_id":85632757,
     "wof:placetype":"region",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.