### PR TITLE
gw concordances, placetype local, and more

### DIFF
--- a/data/110/875/818/5/1108758185.geojson
+++ b/data/110/875/818/5/1108758185.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.064929,
-    "geom:area_square_m":784798368.556406,
+    "geom:area_square_m":784798537.122351,
     "geom:bbox":"-14.845018,12.028838,-14.448037,12.35055",
     "geom:latitude":12.176454,
     "geom:longitude":-14.622019,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"GW.BA.BF"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GW",
     "wof:created":1481309799,
-    "wof:geomhash":"c1d03280b1f1f7c51a16b715eb43c4e9",
+    "wof:geomhash":"cc23c99f2dbdb4defb78e8db9937a703",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108758185,
-    "wof:lastmodified":1627522161,
+    "wof:lastmodified":1695886629,
     "wof:name":"Bafata",
     "wof:parent_id":85671557,
     "wof:placetype":"county",

--- a/data/110/875/818/7/1108758187.geojson
+++ b/data/110/875/818/7/1108758187.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.066395,
-    "geom:area_square_m":802976845.487345,
+    "geom:area_square_m":802976845.487319,
     "geom:bbox":"-15.0710443643,11.8352162489,-14.7177652859,12.2041647446",
     "geom:latitude":12.024065,
     "geom:longitude":-14.899643,
@@ -92,9 +92,10 @@
     "wof:concordances":{
         "hasc:id":"GW.BA.BM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GW",
     "wof:created":1481309801,
-    "wof:geomhash":"8a6bdf24184d4d71be1d022d93d32b0a",
+    "wof:geomhash":"a0b75aa2f1326c811283f391817d6ba4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1108758187,
-    "wof:lastmodified":1566644092,
+    "wof:lastmodified":1695886348,
     "wof:name":"Bambadinca",
     "wof:parent_id":85671557,
     "wof:placetype":"county",

--- a/data/110/875/818/9/1108758189.geojson
+++ b/data/110/875/818/9/1108758189.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.129942,
-    "geom:area_square_m":1568440604.001428,
+    "geom:area_square_m":1568440604.001383,
     "geom:bbox":"-14.9063244976,12.2847109877,-14.3405790311,12.681944",
     "geom:latitude":12.537174,
     "geom:longitude":-14.636614,
@@ -92,9 +92,10 @@
     "wof:concordances":{
         "hasc:id":"GW.BA.CB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GW",
     "wof:created":1481309802,
-    "wof:geomhash":"3f62352faa7b71de502f7591c878f313",
+    "wof:geomhash":"8bc4b0c2d23575be396ff72f02477b72",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1108758189,
-    "wof:lastmodified":1566644092,
+    "wof:lastmodified":1695886348,
     "wof:name":"Contuboel",
     "wof:parent_id":85671557,
     "wof:placetype":"county",

--- a/data/110/875/819/1/1108758191.geojson
+++ b/data/110/875/819/1/1108758191.geojson
@@ -77,6 +77,7 @@
     "wof:concordances":{
         "hasc:id":"GW.BA.GM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GW",
     "wof:created":1481309803,
     "wof:geomhash":"8b231ca3d08666483b9ad3e6bfc296e6",
@@ -89,7 +90,7 @@
         }
     ],
     "wof:id":1108758191,
-    "wof:lastmodified":1694498048,
+    "wof:lastmodified":1695886630,
     "wof:name":"Galomaro",
     "wof:parent_id":85671557,
     "wof:placetype":"county",

--- a/data/110/875/819/3/1108758193.geojson
+++ b/data/110/875/819/3/1108758193.geojson
@@ -53,6 +53,7 @@
     "wof:concordances":{
         "hasc:id":"GW.BA.GM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GW",
     "wof:created":1481309804,
     "wof:geomhash":"5e1dea2c047157142dfb96d2de5fd6fc",
@@ -65,7 +66,7 @@
         }
     ],
     "wof:id":1108758193,
-    "wof:lastmodified":1694498072,
+    "wof:lastmodified":1695886292,
     "wof:name":"Gamamudo",
     "wof:parent_id":85671557,
     "wof:placetype":"county",

--- a/data/110/875/819/7/1108758197.geojson
+++ b/data/110/875/819/7/1108758197.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.101487,
-    "geom:area_square_m":1228537968.012922,
+    "geom:area_square_m":1228537968.012963,
     "geom:bbox":"-14.9263047348,11.5934619868,-14.4462106007,11.9318788124",
     "geom:latitude":11.765942,
     "geom:longitude":-14.692104,
@@ -92,9 +92,10 @@
     "wof:concordances":{
         "hasc:id":"GW.BA.XT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GW",
     "wof:created":1481309805,
-    "wof:geomhash":"2180e5e1d66ec5850744d16b4bdd9a9a",
+    "wof:geomhash":"cfccd4dc18f34424ef61b92ce776dab4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1108758197,
-    "wof:lastmodified":1566644094,
+    "wof:lastmodified":1695886348,
     "wof:name":"Xitole",
     "wof:parent_id":85671557,
     "wof:placetype":"county",

--- a/data/110/875/819/9/1108758199.geojson
+++ b/data/110/875/819/9/1108758199.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.013427,
-    "geom:area_square_m":162508051.672008,
+    "geom:area_square_m":162508051.671999,
     "geom:bbox":"-15.832972527,11.743721962,-15.6567051204,11.8788214469",
     "geom:latitude":11.817354,
     "geom:longitude":-15.751514,
@@ -92,9 +92,10 @@
     "wof:concordances":{
         "hasc:id":"GW.BM.PB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GW",
     "wof:created":1481309806,
-    "wof:geomhash":"ca7b4316d2b13a5185cb6ea6e6a1c198",
+    "wof:geomhash":"b1d8fa86c72cd67125db63f6dbff4204",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1108758199,
-    "wof:lastmodified":1566644094,
+    "wof:lastmodified":1695886348,
     "wof:name":"Prabis",
     "wof:parent_id":85671535,
     "wof:placetype":"county",

--- a/data/110/875/820/1/1108758201.geojson
+++ b/data/110/875/820/1/1108758201.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.036484,
-    "geom:area_square_m":441457417.694678,
+    "geom:area_square_m":441457650.415425,
     "geom:bbox":"-15.968778,11.734555,-15.704035,12.009958",
     "geom:latitude":11.884698,
     "geom:longitude":-15.837924,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"GW.BM.QN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GW",
     "wof:created":1481309807,
-    "wof:geomhash":"d34a795ef622a9797a8a608b298f175c",
+    "wof:geomhash":"b7e72dae8a704f956c9b5ad8f61e2691",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108758201,
-    "wof:lastmodified":1627522162,
+    "wof:lastmodified":1695886630,
     "wof:name":"Quinhamel",
     "wof:parent_id":85671535,
     "wof:placetype":"county",

--- a/data/110/875/820/3/1108758203.geojson
+++ b/data/110/875/820/3/1108758203.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.014091,
-    "geom:area_square_m":170464634.337943,
+    "geom:area_square_m":170464634.337934,
     "geom:bbox":"-15.729132272,11.8540742693,-15.6107520157,12.0280474567",
     "geom:latitude":11.936798,
     "geom:longitude":-15.673073,
@@ -92,9 +92,10 @@
     "wof:concordances":{
         "hasc:id":"GW.BM.SF"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GW",
     "wof:created":1481309808,
-    "wof:geomhash":"b4904c83702b057acaeff8b6aa6c4ad6",
+    "wof:geomhash":"be75922817fee015c800cccf11c81f5f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1108758203,
-    "wof:lastmodified":1566644093,
+    "wof:lastmodified":1695886348,
     "wof:name":"Safim",
     "wof:parent_id":85671535,
     "wof:placetype":"county",

--- a/data/110/875/820/5/1108758205.geojson
+++ b/data/110/875/820/5/1108758205.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007536,
-    "geom:area_square_m":91187981.764985,
+    "geom:area_square_m":91187981.764991,
     "geom:bbox":"-15.662189,11.797055,-15.550796,11.938732",
     "geom:latitude":11.872096,
     "geom:longitude":-15.610759,
@@ -65,13 +65,14 @@
     "wof:concordances":{
         "hasc:id":"GW.BS.BS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:coterminous":[
         85671539,
         421197943
     ],
     "wof:country":"GW",
     "wof:created":1481309810,
-    "wof:geomhash":"1c49a82c8a8f8de315bbb2cfdb1ad1aa",
+    "wof:geomhash":"bc521c3987afab437b94fcc85886caf8",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108758205,
-    "wof:lastmodified":1627522162,
+    "wof:lastmodified":1695886630,
     "wof:name":"Sector Autonomo de Bissau",
     "wof:parent_id":85671539,
     "wof:placetype":"county",

--- a/data/110/875/820/7/1108758207.geojson
+++ b/data/110/875/820/7/1108758207.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.022479,
-    "geom:area_square_m":272295923.8862,
+    "geom:area_square_m":272295319.976021,
     "geom:bbox":"-15.737917,11.432889,-15.322083,11.686016",
     "geom:latitude":11.580535,
     "geom:longitude":-15.488815,
@@ -152,9 +152,10 @@
     "wof:concordances":{
         "hasc:id":"GW.BL.BO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GW",
     "wof:created":1481309811,
-    "wof:geomhash":"406920bec442d6cb66e66963ede0c991",
+    "wof:geomhash":"488fd6d53ee9534bc969ec8f4d418008",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -164,7 +165,7 @@
         }
     ],
     "wof:id":1108758207,
-    "wof:lastmodified":1636494423,
+    "wof:lastmodified":1695886541,
     "wof:name":"Bolama",
     "wof:parent_id":85671543,
     "wof:placetype":"county",

--- a/data/110/875/820/9/1108758209.geojson
+++ b/data/110/875/820/9/1108758209.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.036364,
-    "geom:area_square_m":441094757.812578,
+    "geom:area_square_m":441094757.812597,
     "geom:bbox":"-16.065471649,10.988750458,-15.610472679,11.382111549",
     "geom:latitude":11.19323,
     "geom:longitude":-15.866182,
@@ -113,9 +113,10 @@
     "wof:concordances":{
         "hasc:id":"GW.BL.BQ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GW",
     "wof:created":1481309812,
-    "wof:geomhash":"76611c6573ae6fe26c34aa1c280a0222",
+    "wof:geomhash":"1f9851dab5c93fbd9e0383adef6bffd7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -125,7 +126,7 @@
         }
     ],
     "wof:id":1108758209,
-    "wof:lastmodified":1566644092,
+    "wof:lastmodified":1695886348,
     "wof:name":"Bubaque",
     "wof:parent_id":85671543,
     "wof:placetype":"county",

--- a/data/110/875/821/1/1108758211.geojson
+++ b/data/110/875/821/1/1108758211.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.035241,
-    "geom:area_square_m":427005068.42056,
+    "geom:area_square_m":427005068.420573,
     "geom:bbox":"-16.420473099,11.424528122,-15.89541626,11.610361099",
     "geom:latitude":11.507189,
     "geom:longitude":-16.126833,
@@ -110,9 +110,10 @@
     "wof:concordances":{
         "hasc:id":"GW.BL.CR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GW",
     "wof:created":1481309813,
-    "wof:geomhash":"962b6baaa132ee4310ab15e30cd0bcd0",
+    "wof:geomhash":"31ef8c6f713fc2fbb6e5531ed2ec8c57",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -122,7 +123,7 @@
         }
     ],
     "wof:id":1108758211,
-    "wof:lastmodified":1566644094,
+    "wof:lastmodified":1695886349,
     "wof:name":"Caravela",
     "wof:parent_id":85671543,
     "wof:placetype":"county",

--- a/data/110/875/821/5/1108758215.geojson
+++ b/data/110/875/821/5/1108758215.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.040553,
-    "geom:area_square_m":491905942.711657,
+    "geom:area_square_m":491905942.71165,
     "geom:bbox":"-16.482139587,11.022083282,-15.99458313,11.42788887",
     "geom:latitude":11.19251,
     "geom:longitude":-16.154968,
@@ -113,9 +113,10 @@
     "wof:concordances":{
         "hasc:id":"GW.BL.UN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GW",
     "wof:created":1481309814,
-    "wof:geomhash":"bdc9173fe17a0d2f580cc783e9b5ea60",
+    "wof:geomhash":"ba9a4a1a9e605db3c1cdc75010fc687a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -125,7 +126,7 @@
         }
     ],
     "wof:id":1108758215,
-    "wof:lastmodified":1566644094,
+    "wof:lastmodified":1695886349,
     "wof:name":"Uno",
     "wof:parent_id":85671543,
     "wof:placetype":"county",

--- a/data/110/875/821/7/1108758217.geojson
+++ b/data/110/875/821/7/1108758217.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.082456,
-    "geom:area_square_m":995901420.14845,
+    "geom:area_square_m":995901420.148452,
     "geom:bbox":"-16.1088668382,12.213830482,-15.4797719471,12.522155852",
     "geom:latitude":12.373783,
     "geom:longitude":-15.784079,
@@ -89,9 +89,10 @@
     "wof:concordances":{
         "hasc:id":"GW.CA.BG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GW",
     "wof:created":1481309815,
-    "wof:geomhash":"506b0b39f7deb31dffc8569674b42adf",
+    "wof:geomhash":"a9581380c3657647f2e8a24e32c48412",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1108758217,
-    "wof:lastmodified":1566644093,
+    "wof:lastmodified":1695886348,
     "wof:name":"Bigene",
     "wof:parent_id":85671547,
     "wof:placetype":"county",

--- a/data/110/875/821/9/1108758219.geojson
+++ b/data/110/875/821/9/1108758219.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.054992,
-    "geom:area_square_m":664813194.949762,
+    "geom:area_square_m":664812852.882839,
     "geom:bbox":"-15.944613,11.983755,-15.620853,12.305588",
     "geom:latitude":12.127956,
     "geom:longitude":-15.788625,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"GW.CA.BL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GW",
     "wof:created":1481309816,
-    "wof:geomhash":"70f399c8f0c4c620323be982b4718453",
+    "wof:geomhash":"5cf42576b82fb955b62e87ab4d721dd0",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108758219,
-    "wof:lastmodified":1627522162,
+    "wof:lastmodified":1695886630,
     "wof:name":"Bula",
     "wof:parent_id":85671547,
     "wof:placetype":"county",

--- a/data/110/875/822/1/1108758221.geojson
+++ b/data/110/875/822/1/1108758221.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.076893,
-    "geom:area_square_m":929405402.849753,
+    "geom:area_square_m":929405259.339102,
     "geom:bbox":"-16.352083,11.994555,-15.92271,12.337201",
     "geom:latitude":12.176126,
     "geom:longitude":-16.136536,
@@ -155,9 +155,10 @@
     "wof:concordances":{
         "hasc:id":"GW.CA.CU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GW",
     "wof:created":1481309817,
-    "wof:geomhash":"ade615db9097197a50e2f868e169f961",
+    "wof:geomhash":"c1ce0e6932cec8dc0cea9b7eaebb16eb",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -167,7 +168,7 @@
         }
     ],
     "wof:id":1108758221,
-    "wof:lastmodified":1636494424,
+    "wof:lastmodified":1695886541,
     "wof:name":"Cacheu",
     "wof:parent_id":85671547,
     "wof:placetype":"county",

--- a/data/110/875/822/3/1108758223.geojson
+++ b/data/110/875/822/3/1108758223.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.042136,
-    "geom:area_square_m":509827090.527164,
+    "geom:area_square_m":509827063.995349,
     "geom:bbox":"-16.333778,11.756222,-15.978723,12.035402",
     "geom:latitude":11.899413,
     "geom:longitude":-16.157321,
@@ -102,9 +102,10 @@
         "hasc:id":"GW.CA.CI",
         "wd:id":"Q3649970"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GW",
     "wof:created":1481309819,
-    "wof:geomhash":"b836abd7973cc5a62a063baef8560d76",
+    "wof:geomhash":"295df45485a58a34906b9ed9b133a2d1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -114,7 +115,7 @@
         }
     ],
     "wof:id":1108758223,
-    "wof:lastmodified":1690930128,
+    "wof:lastmodified":1695886630,
     "wof:name":"Caio",
     "wof:parent_id":85671547,
     "wof:placetype":"county",

--- a/data/110/875/822/5/1108758225.geojson
+++ b/data/110/875/822/5/1108758225.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.053221,
-    "geom:area_square_m":643611403.431112,
+    "geom:area_square_m":643611403.431153,
     "geom:bbox":"-16.1970108283,11.89541626,-15.8620280598,12.2167724131",
     "geom:latitude":12.041824,
     "geom:longitude":-16.006859,
@@ -104,9 +104,10 @@
     "wof:concordances":{
         "hasc:id":"GW.CA.CN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GW",
     "wof:created":1481309820,
-    "wof:geomhash":"d089a1272acbabe598e8fc8c9ca87aea",
+    "wof:geomhash":"8be5ffffabc6e4349af47d7901810605",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1108758225,
-    "wof:lastmodified":1566644099,
+    "wof:lastmodified":1695886350,
     "wof:name":"Canchungo",
     "wof:parent_id":85671547,
     "wof:placetype":"county",

--- a/data/110/875/822/7/1108758227.geojson
+++ b/data/110/875/822/7/1108758227.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.085165,
-    "geom:area_square_m":1028788089.941683,
+    "geom:area_square_m":1028788238.107284,
     "geom:bbox":"-16.711828,12.181222,-16.023622,12.472778",
     "geom:latitude":12.33096,
     "geom:longitude":-16.324258,
@@ -99,9 +99,10 @@
         "hasc:id":"GW.CA.SD",
         "wd:id":"Q771106"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GW",
     "wof:created":1481309821,
-    "wof:geomhash":"2eff78ef103381f77f0d1a1b5032dc9e",
+    "wof:geomhash":"4e2e7e7e7d0bb7633478d51e10d192bb",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -111,7 +112,7 @@
         }
     ],
     "wof:id":1108758227,
-    "wof:lastmodified":1690930128,
+    "wof:lastmodified":1695886350,
     "wof:name":"Sao Domingos",
     "wof:parent_id":85671547,
     "wof:placetype":"county",

--- a/data/110/875/822/9/1108758229.geojson
+++ b/data/110/875/822/9/1108758229.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.265296,
-    "geom:area_square_m":3210719325.990977,
+    "geom:area_square_m":3210719404.279843,
     "geom:bbox":"-14.512558,11.559308,-13.696547,12.162373",
     "geom:latitude":11.83321,
     "geom:longitude":-14.068262,
@@ -104,9 +104,10 @@
     "wof:concordances":{
         "hasc:id":"GW.GA.BE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GW",
     "wof:created":1481309822,
-    "wof:geomhash":"c03917d4fa0c078a84d1a6625632a3ec",
+    "wof:geomhash":"d21340efd121fc3c8e6282ba2a5f4589",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1108758229,
-    "wof:lastmodified":1636494424,
+    "wof:lastmodified":1695886542,
     "wof:name":"Boe",
     "wof:parent_id":85671559,
     "wof:placetype":"county",

--- a/data/110/875/823/3/1108758233.geojson
+++ b/data/110/875/823/3/1108758233.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.183287,
-    "geom:area_square_m":2215738426.847084,
+    "geom:area_square_m":2215738426.847096,
     "geom:bbox":"-14.5449885983,11.8930432233,-13.9841095087,12.4530238996",
     "geom:latitude":12.134549,
     "geom:longitude":-14.253013,
@@ -71,9 +71,10 @@
     "wof:concordances":{
         "hasc:id":"GW.GA.GB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GW",
     "wof:created":1481309823,
-    "wof:geomhash":"108329aa7776c7a14d07bb71fe67a30a",
+    "wof:geomhash":"6446d39e8ea4678ff535548a33e80689",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":1108758233,
-    "wof:lastmodified":1566644096,
+    "wof:lastmodified":1695886349,
     "wof:name":"Gabu",
     "wof:parent_id":85671559,
     "wof:placetype":"county",

--- a/data/110/875/823/5/1108758235.geojson
+++ b/data/110/875/823/5/1108758235.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.082845,
-    "geom:area_square_m":999826350.066228,
+    "geom:area_square_m":999826408.897148,
     "geom:bbox":"-14.349876,12.406848,-13.846087,12.678889",
     "geom:latitude":12.572185,
     "geom:longitude":-14.119978,
@@ -102,9 +102,10 @@
         "hasc:id":"GW.GA.PD",
         "wd:id":"Q1771304"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GW",
     "wof:created":1481309824,
-    "wof:geomhash":"9034cf6549403e9f0472b0ead0e21b1f",
+    "wof:geomhash":"4485b45f54dd4335197ac8a6dd681c8b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -114,7 +115,7 @@
         }
     ],
     "wof:id":1108758235,
-    "wof:lastmodified":1690930127,
+    "wof:lastmodified":1695886349,
     "wof:name":"Pirada",
     "wof:parent_id":85671559,
     "wof:placetype":"county",

--- a/data/110/875/823/7/1108758237.geojson
+++ b/data/110/875/823/7/1108758237.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.162174,
-    "geom:area_square_m":1958452982.812226,
+    "geom:area_square_m":1958452867.126243,
     "geom:bbox":"-14.180978,12.12652,-13.626523,12.675373",
     "geom:latitude":12.410255,
     "geom:longitude":-13.879435,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"GW.GA.PT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GW",
     "wof:created":1481309831,
-    "wof:geomhash":"e8e4f03dca4a73a7f0ee48bbf593b5e2",
+    "wof:geomhash":"70163d3d19ef6ed63ecc034e547f45b7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108758237,
-    "wof:lastmodified":1627522162,
+    "wof:lastmodified":1695886630,
     "wof:name":"Pitche",
     "wof:parent_id":85671559,
     "wof:placetype":"county",

--- a/data/110/875/823/9/1108758239.geojson
+++ b/data/110/875/823/9/1108758239.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.066324,
-    "geom:area_square_m":800913740.167522,
+    "geom:area_square_m":800913740.167623,
     "geom:bbox":"-14.5591410425,12.1395239279,-14.2372317866,12.6388329626",
     "geom:latitude":12.419106,
     "geom:longitude":-14.400374,
@@ -86,9 +86,10 @@
     "wof:concordances":{
         "hasc:id":"GW.GA.SN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GW",
     "wof:created":1481309832,
-    "wof:geomhash":"e83a58d83faac56ad7dd6608147b389c",
+    "wof:geomhash":"0505be037f80816ce2763959004394b7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -98,7 +99,7 @@
         }
     ],
     "wof:id":1108758239,
-    "wof:lastmodified":1566644096,
+    "wof:lastmodified":1695886349,
     "wof:name":"Sonaco",
     "wof:parent_id":85671559,
     "wof:placetype":"county",

--- a/data/110/875/824/1/1108758241.geojson
+++ b/data/110/875/824/1/1108758241.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.099633,
-    "geom:area_square_m":1204122208.292558,
+    "geom:area_square_m":1204121962.320777,
     "geom:bbox":"-15.755686,11.99112,-15.282973,12.409184",
     "geom:latitude":12.208734,
     "geom:longitude":-15.535322,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"GW.OI.BR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GW",
     "wof:created":1481309833,
-    "wof:geomhash":"daf57fa51dd8eb607df9db0d30ac1167",
+    "wof:geomhash":"873a6462911eafd91444a4fb88eae4ac",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108758241,
-    "wof:lastmodified":1627522161,
+    "wof:lastmodified":1695886629,
     "wof:name":"Bissora",
     "wof:parent_id":85671551,
     "wof:placetype":"county",

--- a/data/110/875/824/3/1108758243.geojson
+++ b/data/110/875/824/3/1108758243.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.134912,
-    "geom:area_square_m":1628414043.164181,
+    "geom:area_square_m":1628413927.309597,
     "geom:bbox":"-15.487259,12.371317,-14.84694,12.684722",
     "geom:latitude":12.541031,
     "geom:longitude":-15.152345,
@@ -140,9 +140,10 @@
     "wof:concordances":{
         "hasc:id":"GW.OI.FM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GW",
     "wof:created":1481309834,
-    "wof:geomhash":"672d85345d2832516b250ed88c79c0a4",
+    "wof:geomhash":"0360df819956815d82da4ea8e9de572a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -152,7 +153,7 @@
         }
     ],
     "wof:id":1108758243,
-    "wof:lastmodified":1636494423,
+    "wof:lastmodified":1695886541,
     "wof:name":"Farim",
     "wof:parent_id":85671551,
     "wof:placetype":"county",

--- a/data/110/875/824/5/1108758245.geojson
+++ b/data/110/875/824/5/1108758245.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.101361,
-    "geom:area_square_m":1224481999.829347,
+    "geom:area_square_m":1224481955.484694,
     "geom:bbox":"-15.458984,12.174566,-14.936617,12.477876",
     "geom:latitude":12.319875,
     "geom:longitude":-15.166345,
@@ -102,9 +102,10 @@
         "hasc:id":"GW.OI.MB",
         "wd:id":"Q1771615"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GW",
     "wof:created":1481309835,
-    "wof:geomhash":"36916c4f19803f75c8159b5cd2e2aa3f",
+    "wof:geomhash":"ca14f7f6d1de9dc79c194945e3950cae",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -114,7 +115,7 @@
         }
     ],
     "wof:id":1108758245,
-    "wof:lastmodified":1690930127,
+    "wof:lastmodified":1695886350,
     "wof:name":"Mansaba",
     "wof:parent_id":85671551,
     "wof:placetype":"county",

--- a/data/110/875/824/7/1108758247.geojson
+++ b/data/110/875/824/7/1108758247.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.096574,
-    "geom:area_square_m":1167787773.244631,
+    "geom:area_square_m":1167787497.433054,
     "geom:bbox":"-15.453551,11.908722,-14.948758,12.206787",
     "geom:latitude":12.063806,
     "geom:longitude":-15.219871,
@@ -74,9 +74,10 @@
     "wof:concordances":{
         "hasc:id":"GW.OI.MO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GW",
     "wof:created":1481309836,
-    "wof:geomhash":"7b5d73ffbe887e81cca29a85586fb6af",
+    "wof:geomhash":"34817495103d74e0c724963ccd8e7fe6",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -86,7 +87,7 @@
         }
     ],
     "wof:id":1108758247,
-    "wof:lastmodified":1627522162,
+    "wof:lastmodified":1695886630,
     "wof:name":"Mansoa",
     "wof:parent_id":85671551,
     "wof:placetype":"county",

--- a/data/110/875/825/1/1108758251.geojson
+++ b/data/110/875/825/1/1108758251.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.022657,
-    "geom:area_square_m":274062863.362616,
+    "geom:area_square_m":274062863.362599,
     "geom:bbox":"-15.6315531417,11.8875908951,-15.3917635223,12.0565745421",
     "geom:latitude":11.977575,
     "geom:longitude":-15.513571,
@@ -89,9 +89,10 @@
     "wof:concordances":{
         "hasc:id":"GW.OI.NH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GW",
     "wof:created":1481309837,
-    "wof:geomhash":"47eed8f5fcd64e40e79e11f52859aac7",
+    "wof:geomhash":"b95a5cd8d7e655f3ef622a86e1a6ff2c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1108758251,
-    "wof:lastmodified":1566644098,
+    "wof:lastmodified":1695886350,
     "wof:name":"Nhacra",
     "wof:parent_id":85671551,
     "wof:placetype":"county",

--- a/data/110/875/825/3/1108758253.geojson
+++ b/data/110/875/825/3/1108758253.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.067594,
-    "geom:area_square_m":818708286.814531,
+    "geom:area_square_m":818708749.375027,
     "geom:bbox":"-15.124832,11.409385,-14.837076,11.835614",
     "geom:latitude":11.612535,
     "geom:longitude":-14.984588,
@@ -107,9 +107,10 @@
     "wof:concordances":{
         "hasc:id":"GW.QU.BB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GW",
     "wof:created":1481309838,
-    "wof:geomhash":"f286cfae797d6ad610bf2c593774b52a",
+    "wof:geomhash":"ded233cff8c7b4ec3564e5865381a67d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":1108758253,
-    "wof:lastmodified":1627522162,
+    "wof:lastmodified":1695886630,
     "wof:name":"Buba",
     "wof:parent_id":85671555,
     "wof:placetype":"county",

--- a/data/110/875/825/5/1108758255.geojson
+++ b/data/110/875/825/5/1108758255.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.054272,
-    "geom:area_square_m":657612513.275931,
+    "geom:area_square_m":657612916.48555,
     "geom:bbox":"-15.505445,11.324583,-15.074583,11.641222",
     "geom:latitude":11.498771,
     "geom:longitude":-15.283501,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"GW.QU.EM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GW",
     "wof:created":1481309839,
-    "wof:geomhash":"ae4aa45ffb4fac54bc47c49b4f34560d",
+    "wof:geomhash":"53402397bf2b82e3cd71de746d448d86",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108758255,
-    "wof:lastmodified":1627522162,
+    "wof:lastmodified":1695886631,
     "wof:name":"Empada",
     "wof:parent_id":85671555,
     "wof:placetype":"county",

--- a/data/110/875/825/7/1108758257.geojson
+++ b/data/110/875/825/7/1108758257.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.067718,
-    "geom:area_square_m":819681428.325981,
+    "geom:area_square_m":819681085.421292,
     "geom:bbox":"-15.307944,11.632028,-14.935968,11.955389",
     "geom:latitude":11.789705,
     "geom:longitude":-15.1316,
@@ -134,9 +134,10 @@
     "wof:concordances":{
         "hasc:id":"GW.QU.FC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GW",
     "wof:created":1481309840,
-    "wof:geomhash":"a531d8ffadb2d526322055cb824164b5",
+    "wof:geomhash":"eb8199b7460e12dc69db80c1d2af0207",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -146,7 +147,7 @@
         }
     ],
     "wof:id":1108758257,
-    "wof:lastmodified":1636494424,
+    "wof:lastmodified":1695886542,
     "wof:name":"Fulacunda",
     "wof:parent_id":85671555,
     "wof:placetype":"county",

--- a/data/110/875/825/9/1108758259.geojson
+++ b/data/110/875/825/9/1108758259.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.045008,
-    "geom:area_square_m":544843569.38634,
+    "geom:area_square_m":544843576.226338,
     "geom:bbox":"-15.621278,11.623722,-15.26875,11.891222",
     "geom:latitude":11.762761,
     "geom:longitude":-15.39466,
@@ -87,9 +87,10 @@
         "hasc:id":"GW.QU.TT",
         "wd:id":"Q3991840"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GW",
     "wof:created":1481309842,
-    "wof:geomhash":"4be85b72479be09590b5d97a60600901",
+    "wof:geomhash":"68763b356a44cc50b494ac6f1a53cec8",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -99,7 +100,7 @@
         }
     ],
     "wof:id":1108758259,
-    "wof:lastmodified":1627522163,
+    "wof:lastmodified":1695886632,
     "wof:name":"Tite",
     "wof:parent_id":85671555,
     "wof:placetype":"county",

--- a/data/110/875/826/1/1108758261.geojson
+++ b/data/110/875/826/1/1108758261.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.087306,
-    "geom:area_square_m":1058759143.517202,
+    "geom:area_square_m":1058759321.356455,
     "geom:bbox":"-15.272972,10.994583,-14.787421,11.441889",
     "geom:latitude":11.262569,
     "geom:longitude":-15.044961,
@@ -89,9 +89,10 @@
     "wof:concordances":{
         "hasc:id":"GW.TO.BD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GW",
     "wof:created":1481309843,
-    "wof:geomhash":"2ccadc2eda4d2a93d665b5432e92f25f",
+    "wof:geomhash":"4399ae25ebcc8fa087d300b060850dae",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1108758261,
-    "wof:lastmodified":1627522161,
+    "wof:lastmodified":1695886629,
     "wof:name":"Bedanda",
     "wof:parent_id":85671561,
     "wof:placetype":"county",

--- a/data/110/875/826/3/1108758263.geojson
+++ b/data/110/875/826/3/1108758263.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.048592,
-    "geom:area_square_m":589604082.414611,
+    "geom:area_square_m":589604548.43911,
     "geom:bbox":"-15.11125,10.918722,-14.812496,11.283607",
     "geom:latitude":11.104581,
     "geom:longitude":-14.969925,
@@ -89,9 +89,10 @@
     "wof:concordances":{
         "hasc:id":"GW.TO.CC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GW",
     "wof:created":1481309844,
-    "wof:geomhash":"23cd0e6f757110ef0ad239a39111e320",
+    "wof:geomhash":"fa59062b0654f1820ea2e5e37b5f30e0",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1108758263,
-    "wof:lastmodified":1627522162,
+    "wof:lastmodified":1695886631,
     "wof:name":"Cacine",
     "wof:parent_id":85671561,
     "wof:placetype":"county",

--- a/data/110/875/826/5/1108758265.geojson
+++ b/data/110/875/826/5/1108758265.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.051951,
-    "geom:area_square_m":629837148.911018,
+    "geom:area_square_m":629837384.535147,
     "geom:bbox":"-15.421306,11.213864,-15.095295,11.479446",
     "geom:latitude":11.344095,
     "geom:longitude":-15.250848,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"GW.TO.CO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GW",
     "wof:created":1481309845,
-    "wof:geomhash":"f4662bde8ba9a3be34c12546c67cc801",
+    "wof:geomhash":"7cf156b88c1eed687030251e51a7e7a2",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108758265,
-    "wof:lastmodified":1627522162,
+    "wof:lastmodified":1695886631,
     "wof:name":"Catio",
     "wof:parent_id":85671561,
     "wof:placetype":"county",

--- a/data/110/875/826/9/1108758269.geojson
+++ b/data/110/875/826/9/1108758269.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.017781,
-    "geom:area_square_m":215685221.64721,
+    "geom:area_square_m":215685221.647231,
     "geom:bbox":"-15.411277771,11.113750458,-15.2152494413,11.2731685732",
     "geom:latitude":11.191165,
     "geom:longitude":-15.314458,
@@ -92,9 +92,10 @@
     "wof:concordances":{
         "hasc:id":"GW.TO.KO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GW",
     "wof:created":1481309846,
-    "wof:geomhash":"737435dcc6a65bfab73430677a434842",
+    "wof:geomhash":"c3f7a2bfe2f61e80f90c32333fcf57e6",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1108758269,
-    "wof:lastmodified":1566644095,
+    "wof:lastmodified":1695886349,
     "wof:name":"Komo",
     "wof:parent_id":85671561,
     "wof:placetype":"county",

--- a/data/110/875/827/1/1108758271.geojson
+++ b/data/110/875/827/1/1108758271.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.086846,
-    "geom:area_square_m":1052188460.095227,
+    "geom:area_square_m":1052188460.095222,
     "geom:bbox":"-14.9552359258,11.329173492,-14.4067324706,11.6989695375",
     "geom:latitude":11.530762,
     "geom:longitude":-14.721804,
@@ -89,9 +89,10 @@
     "wof:concordances":{
         "hasc:id":"GW.TO.QB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GW",
     "wof:created":1481309847,
-    "wof:geomhash":"3a3991dd2b44f415cfbda022cb0b3905",
+    "wof:geomhash":"952d3a55f251b6e325b58e8880bb2b28",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1108758271,
-    "wof:lastmodified":1566644092,
+    "wof:lastmodified":1695886348,
     "wof:name":"Quebo",
     "wof:parent_id":85671561,
     "wof:placetype":"county",

--- a/data/856/327/57/85632757.geojson
+++ b/data/856/327/57/85632757.geojson
@@ -1177,6 +1177,7 @@
         "hasc:id":"GW",
         "icao:code":"J5",
         "ioc:id":"GBS",
+        "iso:code":"GW",
         "itu:id":"GNB",
         "m49:code":"624",
         "marc:id":"pg",
@@ -1190,6 +1191,7 @@
         "wk:page":"Guinea-Bissau",
         "wmo:id":"GW"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GW",
     "wof:country_alpha3":"GNB",
     "wof:geom_alt":[
@@ -1211,7 +1213,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1694639495,
+    "wof:lastmodified":1695881148,
     "wof:name":"Guinea Bissau",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/715/35/85671535.geojson
+++ b/data/856/715/35/85671535.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.064001,
-    "geom:area_square_m":774430103.704618,
+    "geom:area_square_m":774430364.85623,
     "geom:bbox":"-15.968778,11.734555,-15.610752,12.028047",
     "geom:latitude":11.88204,
     "geom:longitude":-15.783502,
@@ -279,17 +279,19 @@
         "gn:id":2374820,
         "gp:id":2346611,
         "hasc:id":"GW.BM",
+        "iso:code":"GW-BM",
         "iso:id":"GW-BM",
         "qs_pg:id":988723,
         "unlc:id":"GW-BM",
         "wd:id":"Q872228",
         "wk:page":"Biombo Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GW",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"573471a6d33eb51a126d7d05c305f629",
+    "wof:geomhash":"ad61670f030e2981671467ebf6b97099",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -304,7 +306,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1690930123,
+    "wof:lastmodified":1695884762,
     "wof:name":"Biombo",
     "wof:parent_id":85632757,
     "wof:placetype":"region",

--- a/data/856/715/39/85671539.geojson
+++ b/data/856/715/39/85671539.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007536,
-    "geom:area_square_m":91187981.764987,
+    "geom:area_square_m":91187981.764997,
     "geom:bbox":"-15.662189,11.797055,-15.550796,11.938732",
     "geom:latitude":11.872096,
     "geom:longitude":-15.610759,
@@ -593,11 +593,13 @@
         "gn:id":2374776,
         "gp:id":2346610,
         "hasc:id":"GW.BS",
+        "iso:code":"GW-BS",
         "iso:id":"GW-BS",
         "qs_pg:id":318644,
         "wd:id":"Q3739",
         "wk:page":"Bissau"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         421197943,
         1108758205
@@ -606,7 +608,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8e4d1c7e7b857c8f8d6dec3419890234",
+    "wof:geomhash":"b3cab57c83dc670f8461a5bf6e53c677",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -621,7 +623,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1690930124,
+    "wof:lastmodified":1695884464,
     "wof:name":"Bissau",
     "wof:parent_id":85632757,
     "wof:placetype":"region",

--- a/data/856/715/43/85671543.geojson
+++ b/data/856/715/43/85671543.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.134637,
-    "geom:area_square_m":1632301692.830979,
+    "geom:area_square_m":1632300534.695322,
     "geom:bbox":"-16.48214,10.98875,-15.322083,11.686016",
     "geom:latitude":11.339856,
     "geom:longitude":-15.958386,
@@ -293,17 +293,19 @@
         "gn:id":2374689,
         "gp:id":2346606,
         "hasc:id":"GW.BL",
+        "iso:code":"GW-BL",
         "iso:id":"GW-BL",
         "qs_pg:id":1168722,
         "unlc:id":"GW-BL",
         "wd:id":"Q151909",
         "wk:page":"Bolama Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GW",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"46571445d5a22b43142b72d8c4177d56",
+    "wof:geomhash":"bc48e9d3a84dd39c821c206802c02d79",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -318,7 +320,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1690930123,
+    "wof:lastmodified":1695884763,
     "wof:name":"Bolama",
     "wof:parent_id":85632757,
     "wof:placetype":"region",

--- a/data/856/715/47/85671547.geojson
+++ b/data/856/715/47/85671547.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.394864,
-    "geom:area_square_m":4772346601.847474,
+    "geom:area_square_m":4772346641.03028,
     "geom:bbox":"-16.711828,11.756222,-15.479772,12.522156",
     "geom:latitude":12.196457,
     "geom:longitude":-16.03971,
@@ -260,17 +260,19 @@
         "gn:id":2374312,
         "gp:id":2346607,
         "hasc:id":"GW.CA",
+        "iso:code":"GW-CA",
         "iso:id":"GW-CA",
         "qs_pg:id":573799,
         "unlc:id":"GW-CA",
         "wd:id":"Q780838",
         "wk:page":"Cacheu Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GW",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5217fa3b4c62f8f0ee0cb85fd7a5b4fb",
+    "wof:geomhash":"c4f58b767c0105d81675fe74653c3f13",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -285,7 +287,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1690930124,
+    "wof:lastmodified":1695884763,
     "wof:name":"Cacheu",
     "wof:parent_id":85632757,
     "wof:placetype":"region",

--- a/data/856/715/51/85671551.geojson
+++ b/data/856/715/51/85671551.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.455138,
-    "geom:area_square_m":5498868887.893333,
+    "geom:area_square_m":5498868418.146829,
     "geom:bbox":"-15.755686,11.887591,-14.84694,12.684722",
     "geom:latitude":12.289726,
     "geom:longitude":-15.27161,
@@ -292,17 +292,19 @@
         "gn:id":2371071,
         "gp:id":2346605,
         "hasc:id":"GW.OI",
+        "iso:code":"GW-OI",
         "iso:id":"GW-OI",
         "qs_pg:id":496860,
         "unlc:id":"GW-OI",
         "wd:id":"Q853991",
         "wk:page":"Oio Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GW",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"bf96dadad5dd40c50d823ba6cf5d94d6",
+    "wof:geomhash":"9ea0124dff3579389677dadcef5dab6b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -317,7 +319,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1690930123,
+    "wof:lastmodified":1695884762,
     "wof:name":"Oio",
     "wof:parent_id":85632757,
     "wof:placetype":"region",

--- a/data/856/715/55/85671555.geojson
+++ b/data/856/715/55/85671555.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.234592,
-    "geom:area_square_m":2840845797.80286,
+    "geom:area_square_m":2840846327.508258,
     "geom:bbox":"-15.621278,11.324583,-14.837076,11.955389",
     "geom:latitude":11.66618,
     "geom:longitude":-15.174852,
@@ -282,17 +282,19 @@
         "gn:id":2370360,
         "gp:id":2346604,
         "hasc:id":"GW.QU",
+        "iso:code":"GW-QU",
         "iso:id":"GW-QU",
         "qs_pg:id":496859,
         "unlc:id":"GW-QU",
         "wd:id":"Q862617",
         "wk:page":"Quinara Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GW",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"59e9194e66ddc270fc43e06399d523c8",
+    "wof:geomhash":"ed07218a0bd6db336251e3534bafa6f2",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -307,7 +309,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1690930124,
+    "wof:lastmodified":1695884763,
     "wof:name":"Quinara",
     "wof:parent_id":85632757,
     "wof:placetype":"region",

--- a/data/856/715/57/85671557.geojson
+++ b/data/856/715/57/85671557.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.484719,
-    "geom:area_square_m":5859005677.7181,
+    "geom:area_square_m":5859006220.191324,
     "geom:bbox":"-15.071044,11.593462,-14.340579,12.681944",
     "geom:latitude":12.163872,
     "geom:longitude":-14.706643,
@@ -270,17 +270,19 @@
         "gn:id":2375255,
         "gp:id":2346603,
         "hasc:id":"GW.BA",
+        "iso:code":"GW-BA",
         "iso:id":"GW-BA",
         "qs_pg:id":318636,
         "unlc:id":"GW-BA",
         "wd:id":"Q799791",
         "wk:page":"Bafat\u00e1 Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GW",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0b62cb2ab5d15fbd4144ea1358aad06b",
+    "wof:geomhash":"88bbf94c0e4eb4228325b8e420be65e1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -295,7 +297,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1690930122,
+    "wof:lastmodified":1695884505,
     "wof:name":"Bafat\u00e1",
     "wof:parent_id":85632757,
     "wof:placetype":"region",

--- a/data/856/715/59/85671559.geojson
+++ b/data/856/715/59/85671559.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.759926,
-    "geom:area_square_m":9185650825.883781,
+    "geom:area_square_m":9185650513.37929,
     "geom:bbox":"-14.559141,11.559308,-13.626523,12.678889",
     "geom:latitude":12.160732,
     "geom:longitude":-14.107149,
@@ -282,17 +282,19 @@
         "gn:id":2372533,
         "gp:id":2346609,
         "hasc:id":"GW.GA",
+        "iso:code":"GW-GA",
         "iso:id":"GW-GA",
         "qs_pg:id":1004451,
         "unlc:id":"GW-GA",
         "wd:id":"Q872212",
         "wk:page":"Gab\u00fa Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GW",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"681a6a953babcc6881372d82a6c37e27",
+    "wof:geomhash":"09fa39716d3e1ee864383561d9d14a02",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -307,7 +309,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1690930121,
+    "wof:lastmodified":1695884330,
     "wof:name":"Gab\u00fa",
     "wof:parent_id":85632757,
     "wof:placetype":"region",

--- a/data/856/715/61/85671561.geojson
+++ b/data/856/715/61/85671561.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.292476,
-    "geom:area_square_m":3546074056.585186,
+    "geom:area_square_m":3546074514.269459,
     "geom:bbox":"-15.421306,10.918722,-14.406732,11.69897",
     "geom:latitude":11.326096,
     "geom:longitude":-14.989494,
@@ -282,17 +282,19 @@
         "gn:id":2368955,
         "gp:id":2346608,
         "hasc:id":"GW.TO",
+        "iso:code":"GW-TO",
         "iso:id":"GW-TO",
         "qs_pg:id":894974,
         "unlc:id":"GW-TO",
         "wd:id":"Q1047255",
         "wk:page":"Tombali Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GW",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e3bf1c228426b0a0c70c3c1e00b8c00e",
+    "wof:geomhash":"b2f3da21013db7ae39b815cacbee1513",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -307,7 +309,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1690930121,
+    "wof:lastmodified":1695884762,
     "wof:name":"Tombali",
     "wof:parent_id":85632757,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.